### PR TITLE
Runtime caches values which will be passed to wasm

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -14,39 +14,23 @@ pub mod value;
 
 mod ext_ffi {
     extern "C" {
-        //TODO: replace size_of* idiom with one in which the calls are explicitly
-        //      paired. E.g. read_value(key_ptr: *const u8, key_size: usize) -> usize;
-        //                   get_read(value_ptr: *mut u8, value_size: usize);
-        //      Note that the second call does not make sense except after the first one.
-        pub fn size_of_value(key_ptr: *const u8, key_size: usize) -> usize;
-        pub fn read(key_ptr: *const u8, key_size: usize, value_ptr: *mut u8, value_size: usize);
+        pub fn read_value(key_ptr: *const u8, key_size: usize) -> usize;
+        pub fn get_read(value_ptr: *mut u8); //can only be called after `read_value`
         pub fn write(key_ptr: *const u8, key_size: usize, value_ptr: *const u8, value_size: usize);
         pub fn add(key_ptr: *const u8, key_size: usize, value_ptr: *const u8, value_size: usize);
         pub fn new_uref(key_ptr: *mut u8);
-        pub fn function_size(name_ptr: *const u8, name_size: usize) -> usize;
-        pub fn function_bytes(
-            name_ptr: *const u8,
-            name_size: usize,
-            dest_ptr: *mut u8,
-            dest_size: usize,
-        );
-        pub fn size_of_arg(i: u32) -> usize;
-        pub fn get_arg(i: u32, dest: *mut u8, size: usize);
+        pub fn serialize_function(name_ptr: *const u8, name_size: usize) -> usize;
+        pub fn get_function(dest_ptr: *mut u8); //can only be called after `serialize_function`
+        pub fn load_arg(i: u32) -> usize;
+        pub fn get_arg(dest: *mut u8); //can only be called after `load_arg`
         pub fn ret(value_ptr: *const u8, value_size: usize) -> !;
-        pub fn size_of_call_result(
-            fn_ptr: *const u8,
-            fn_size: usize,
-            args_ptr: *const u8,
-            args_size: usize,
-        ) -> usize;
         pub fn call_contract(
             fn_ptr: *const u8,
             fn_size: usize,
             args_ptr: *const u8,
             args_size: usize,
-            res_ptr: *mut u8,
-            res_size: usize,
-        );
+        ) -> usize;
+        pub fn get_call_result(res_ptr: *mut u8); //can only be called after `call_contract`
     }
 }
 
@@ -74,21 +58,21 @@ pub mod ext {
         (ptr, size, bytes)
     }
 
-	//Read value under the key in the global state
+    //Read value under the key in the global state
     pub fn read(key: &Key) -> Value {
         //Note: _bytes is necessary to keep the Vec<u8> in scope. If _bytes is
         //      dropped then key_ptr becomes invalid.
         let (key_ptr, key_size, _bytes) = to_ptr(key);
-        let value_size = unsafe { ext_ffi::size_of_value(key_ptr, key_size) };
+        let value_size = unsafe { ext_ffi::read_value(key_ptr, key_size) };
         let value_ptr = alloc_bytes(value_size);
         let value_bytes = unsafe {
-            ext_ffi::read(key_ptr, key_size, value_ptr, value_size);
+            ext_ffi::get_read(value_ptr);
             core::slice::from_raw_parts(value_ptr, value_size)
         };
         deserialize(value_bytes).unwrap()
     }
 
-	//Write the value under the key in the global state
+    //Write the value under the key in the global state
     pub fn write(key: &Key, value: &Value) {
         let (key_ptr, key_size, _bytes) = to_ptr(key);
         let (value_ptr, value_size, _bytes2) = to_ptr(value);
@@ -97,7 +81,7 @@ pub mod ext {
         }
     }
 
-	//Add the given value to the one  currently under the key in the global state
+    //Add the given value to the one  currently under the key in the global state
     pub fn add(key: &Key, value: &Value) {
         let (key_ptr, key_size, _bytes) = to_ptr(key);
         let (value_ptr, value_size, _bytes2) = to_ptr(value);
@@ -106,7 +90,7 @@ pub mod ext {
         }
     }
 
-	//Returns a new unforgable reference Key
+    //Returns a new unforgable reference Key
     pub fn new_uref() -> Key {
         let key_ptr = alloc_bytes(UREF_SIZE);
         let slice = unsafe {
@@ -118,26 +102,26 @@ pub mod ext {
 
     fn fn_bytes_by_name(name: &String) -> Vec<u8> {
         let (name_ptr, name_size, _bytes) = to_ptr(name);
-        let fn_size = unsafe { ext_ffi::function_size(name_ptr, name_size) };
+        let fn_size = unsafe { ext_ffi::serialize_function(name_ptr, name_size) };
         let fn_ptr = alloc_bytes(fn_size);
         unsafe {
-            ext_ffi::function_bytes(name_ptr, name_size, fn_ptr, fn_size);
+            ext_ffi::get_function(fn_ptr);
             Vec::from_raw_parts(fn_ptr, fn_size, fn_size)
         }
     }
 
-	//Returns the serialized bytes of a function which is exported in the current module.
-	//Note that the function is wrapped up in a new module and re-exported under the name
-	//"call". `fn_bytes_by_name` is meant to be used when storing a contract on-chain at
-	//an unforgable reference.
+    //Returns the serialized bytes of a function which is exported in the current module.
+    //Note that the function is wrapped up in a new module and re-exported under the name
+    //"call". `fn_bytes_by_name` is meant to be used when storing a contract on-chain at
+    //an unforgable reference.
     pub fn fn_by_name(name: &String) -> Value {
         let fn_bytes = fn_bytes_by_name(name);
         Value::Contract(fn_bytes)
     }
 
-	//Gets the serialized bytes of an exported function (see `fn_by_name`), then
-	//computes the hash of those bytes to produce a key where the contract is then
-	//stored in the global state. This key is returned.
+    //Gets the serialized bytes of an exported function (see `fn_by_name`), then
+    //computes the hash of those bytes to produce a key where the contract is then
+    //stored in the global state. This key is returned.
     pub fn store_function(name: &String) -> Key {
         let fn_bytes = fn_bytes_by_name(name);
         let mut hasher = VarBlake2b::new(32).unwrap();
@@ -150,24 +134,24 @@ pub mod ext {
         key
     }
 
-	//Return the i-th argument passed to the host for the current module
-	//invokation. Note that this is only relevent to contracts stored on-chain
-	//since a contract deployed directly is not invoked with any arguments.
+    //Return the i-th argument passed to the host for the current module
+    //invokation. Note that this is only relevent to contracts stored on-chain
+    //since a contract deployed directly is not invoked with any arguments.
     pub fn get_arg<T: BytesRepr>(i: u32) -> T {
-        let arg_size = unsafe { ext_ffi::size_of_arg(i) };
+        let arg_size = unsafe { ext_ffi::load_arg(i) };
         let dest_ptr = alloc_bytes(arg_size);
         let arg_bytes = unsafe {
-            ext_ffi::get_arg(i, dest_ptr, arg_size);
+            ext_ffi::get_arg(dest_ptr);
             core::slice::from_raw_parts(dest_ptr, arg_size)
         };
-		//TODO: better error handling (i.e. pass the `Result` on)
+        //TODO: better error handling (i.e. pass the `Result` on)
         deserialize(arg_bytes).unwrap()
     }
 
-	//Return `t` to the host, terminating the currently running module.
-	//Note this function is only relevent to contracts stored on chain which
-	//return a value to their caller. The return value of a directly deployed
-	//contract is never looked at.
+    //Return `t` to the host, terminating the currently running module.
+    //Note this function is only relevent to contracts stored on chain which
+    //return a value to their caller. The return value of a directly deployed
+    //contract is never looked at.
     pub fn ret<T: BytesRepr>(t: &T) -> ! {
         let (ptr, size, _bytes) = to_ptr(t);
         unsafe {
@@ -175,19 +159,18 @@ pub mod ext {
         }
     }
 
-	//Call the given contract, passing the given (serialized) arguments to
-	//the host in order to have them available to the called contract during its
-	//execution. The value returned from the contract call (see `ret` above) is
-	//returned from this function.
+    //Call the given contract, passing the given (serialized) arguments to
+    //the host in order to have them available to the called contract during its
+    //execution. The value returned from the contract call (see `ret` above) is
+    //returned from this function.
     pub fn call_contract<T: BytesRepr>(contract: &Value, args: &Vec<Vec<u8>>) -> T {
         if let Value::Contract(c) = contract {
             let (fn_ptr, fn_size, _bytes) = to_ptr(c);
             let (args_ptr, args_size, _bytes2) = to_ptr(args);
-            let res_size =
-                unsafe { ext_ffi::size_of_call_result(fn_ptr, fn_size, args_ptr, args_size) };
+            let res_size = unsafe { ext_ffi::call_contract(fn_ptr, fn_size, args_ptr, args_size) };
             let res_ptr = alloc_bytes(res_size);
             let res_bytes = unsafe {
-                ext_ffi::call_contract(fn_ptr, fn_size, args_ptr, args_size, res_ptr, res_size);
+                ext_ffi::get_call_result(res_ptr);
                 core::slice::from_raw_parts(res_ptr, res_size)
             };
             deserialize(res_bytes).unwrap()

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -188,7 +188,7 @@ impl<'a, T: TrackingCopy + 'a> Runtime<'a, T> {
         self.set_mem_from_buf(dest_ptr)
     }
 
-    pub fn ser_function(&mut self, args: RuntimeArgs) -> Result<usize, Trap> {
+    pub fn serialize_function(&mut self, args: RuntimeArgs) -> Result<usize, Trap> {
         //args(0) = pointer to name in wasm memory
         //args(1) = size of name in wasm memory
         let name_ptr: u32 = args.nth_checked(0)?;
@@ -279,7 +279,7 @@ impl<'a, T: TrackingCopy + 'a> Externals for Runtime<'a, T> {
             }
 
             SER_FN_FUNC_INDEX => {
-                let size = self.ser_function(args)?;
+                let size = self.serialize_function(args)?;
                 Ok(Some(RuntimeValue::I32(size as i32)))
             }
 

--- a/engine/src/engine.rs
+++ b/engine/src/engine.rs
@@ -67,6 +67,7 @@ pub struct Runtime<'a, T: TrackingCopy + 'a> {
     state: &'a mut T,
     module: Module,
     result: Vec<u8>,
+    host_buf: Vec<u8>,
 }
 
 impl<'a, T: TrackingCopy + 'a> Runtime<'a, T> {
@@ -137,23 +138,19 @@ impl<'a, T: TrackingCopy + 'a> Runtime<'a, T> {
         Ok((key, value))
     }
 
-    pub fn size_of_arg(&self, i: usize) -> Result<usize, Trap> {
+    pub fn load_arg(&mut self, i: usize) -> Result<usize, Trap> {
         if i < self.args.len() {
-            Ok(self.args[i].len())
+            self.host_buf = self.args[i].clone();
+            Ok(self.host_buf.len())
         } else {
             Err(Error::ArgIndexOutOfBounds(i).into())
         }
     }
 
-    pub fn get_arg(&mut self, i: usize, dest_ptr: u32) -> Result<(), Trap> {
-        if i < self.args.len() {
-            let arg = &self.args[i];
-            self.memory
-                .set(dest_ptr, &arg)
-                .map_err(|e| Error::Interpreter(e).into())
-        } else {
-            Err(Error::ArgIndexOutOfBounds(i).into())
-        }
+    fn set_mem_from_buf(&mut self, dest_ptr: u32) -> Result<(), Trap> {
+        self.memory
+            .set(dest_ptr, &self.host_buf)
+            .map_err(|e| Error::Interpreter(e).into())
     }
 
     pub fn ret(&mut self, value_ptr: u32, value_size: usize) -> Trap {
@@ -167,13 +164,13 @@ impl<'a, T: TrackingCopy + 'a> Runtime<'a, T> {
         }
     }
 
-    fn do_call_contract(
+    fn call_contract(
         &mut self,
         fn_ptr: u32,
         fn_size: usize,
         args_ptr: u32,
         args_size: usize,
-    ) -> Result<Vec<u8>, Error> {
+    ) -> Result<usize, Error> {
         let fn_bytes = self.memory.get(fn_ptr, fn_size)?;
         let args_bytes = self.memory.get(args_ptr, args_size)?;
 
@@ -181,56 +178,24 @@ impl<'a, T: TrackingCopy + 'a> Runtime<'a, T> {
         let serialized_module: Vec<u8> = deserialize(&fn_bytes)?;
         let module = parity_wasm::deserialize_buffer(&serialized_module)?;
 
-        let result = sub_call(module, args, self);
-        result
+        let result = sub_call(module, args, self)?;
+        self.host_buf = result;
+        Ok(self.host_buf.len())
     }
 
-    pub fn size_of_call_result(
-        &mut self,
-        fn_ptr: u32,
-        fn_size: usize,
-        args_ptr: u32,
-        args_size: usize,
-    ) -> Result<usize, Trap> {
-        let result = self.do_call_contract(fn_ptr, fn_size, args_ptr, args_size)?;
-        Ok(result.len())
+    pub fn set_mem(&mut self, args: RuntimeArgs) -> Result<(), Trap> {
+        let dest_ptr: u32 = args.nth_checked(0)?;
+        self.set_mem_from_buf(dest_ptr)
     }
 
-    pub fn call_contract(
-        &mut self,
-        fn_ptr: u32,
-        fn_size: usize,
-        args_ptr: u32,
-        args_size: usize,
-        result_ptr: u32,
-    ) -> Result<(), Trap> {
-        let result = self.do_call_contract(fn_ptr, fn_size, args_ptr, args_size)?;
-        self.memory
-            .set(result_ptr, &result)
-            .map_err(|e| Error::Interpreter(e).into())
-    }
-
-    pub fn function_size(&mut self, args: RuntimeArgs) -> Result<usize, Trap> {
+    pub fn ser_function(&mut self, args: RuntimeArgs) -> Result<usize, Trap> {
         //args(0) = pointer to name in wasm memory
         //args(1) = size of name in wasm memory
         let name_ptr: u32 = args.nth_checked(0)?;
         let name_size: u32 = args.nth_checked(1)?;
         let fn_bytes = self.function_from_name(name_ptr, name_size)?;
-        Ok(fn_bytes.len())
-    }
-
-    pub fn function_bytes(&mut self, args: RuntimeArgs) -> Result<(), Trap> {
-        //args(0) = pointer to name in wasm memory
-        //args(1) = size of name
-        //args(2) = pointer to fn dest
-        //args(3) = size of fn dest
-        let name_ptr: u32 = args.nth_checked(0)?;
-        let name_size: u32 = args.nth_checked(1)?;
-        let dest_ptr: u32 = args.nth_checked(2)?;
-        let fn_bytes = self.function_from_name(name_ptr, name_size)?;
-        self.memory
-            .set(dest_ptr, &fn_bytes)
-            .map_err(|e| Error::Interpreter(e).into())
+        self.host_buf = fn_bytes;
+        Ok(self.host_buf.len())
     }
 
     pub fn write(&mut self, args: RuntimeArgs) -> Result<(), Trap> {
@@ -264,31 +229,17 @@ impl<'a, T: TrackingCopy + 'a> Runtime<'a, T> {
         self.state.read(key).map_err(|e| e.into())
     }
 
-    pub fn size_of_value(&mut self, args: RuntimeArgs) -> Result<usize, Trap> {
+    pub fn read_value(&mut self, args: RuntimeArgs) -> Result<usize, Trap> {
         //args(0) = pointer to key in wasm memory
         //args(1) = size of key in wasm memory
-        let key_ptr: u32 = args.nth_checked(0)?;
-        let key_size: u32 = args.nth_checked(1)?;
-        let value = self.value_from_key(key_ptr, key_size)?;
-        let value_bytes = value.to_bytes();
-        Ok(value_bytes.len())
-    }
-
-    pub fn read(&mut self, args: RuntimeArgs) -> Result<(), Trap> {
-        //args(0) = pointer to key in wasm memory
-        //args(1) = size of key in wasm memory
-        //args(2) = value destination pointer
-        //args(3) = size of value
         let key_ptr: u32 = args.nth_checked(0)?;
         let key_size: u32 = args.nth_checked(1)?;
         let value_bytes = {
             let value = self.value_from_key(key_ptr, key_size)?;
             value.to_bytes()
         };
-        let value_ptr: u32 = args.nth_checked(2)?;
-        self.memory
-            .set(value_ptr, &value_bytes)
-            .map_err(|e| Error::Interpreter(e).into())
+        self.host_buf = value_bytes;
+        Ok(self.host_buf.len())
     }
 
     pub fn new_uref(&mut self, args: RuntimeArgs) -> Result<(), Trap> {
@@ -302,18 +253,17 @@ impl<'a, T: TrackingCopy + 'a> Runtime<'a, T> {
     }
 }
 
-//TODO: add other functions
 const WRITE_FUNC_INDEX: usize = 0;
 const READ_FUNC_INDEX: usize = 1;
 const ADD_FUNC_INDEX: usize = 2;
 const NEW_FUNC_INDEX: usize = 3;
-const SIZE_FUNC_INDEX: usize = 4;
-const FN_SIZE_FUNC_INDEX: usize = 5;
-const FN_BYTES_FUNC_INDEX: usize = 6;
-const SIZE_OF_ARG_FUNC_INDEX: usize = 7;
+const GET_READ_FUNC_INDEX: usize = 4;
+const SER_FN_FUNC_INDEX: usize = 5;
+const GET_FN_FUNC_INDEX: usize = 6;
+const LOAD_ARG_FUNC_INDEX: usize = 7;
 const GET_ARG_FUNC_INDEX: usize = 8;
 const RET_FUNC_INDEX: usize = 9;
-const SIZE_OF_CALL_RESULT_FUNC_INDEX: usize = 10;
+const GET_CALL_RESULT_FUNC_INDEX: usize = 10;
 const CALL_CONTRACT_FUNC_INDEX: usize = 11;
 
 impl<'a, T: TrackingCopy + 'a> Externals for Runtime<'a, T> {
@@ -323,13 +273,13 @@ impl<'a, T: TrackingCopy + 'a> Externals for Runtime<'a, T> {
         args: RuntimeArgs,
     ) -> Result<Option<RuntimeValue>, Trap> {
         match index {
-            SIZE_FUNC_INDEX => {
-                let size = self.size_of_value(args)?;
+            READ_FUNC_INDEX => {
+                let size = self.read_value(args)?;
                 Ok(Some(RuntimeValue::I32(size as i32)))
             }
 
-            FN_SIZE_FUNC_INDEX => {
-                let size = self.function_size(args)?;
+            SER_FN_FUNC_INDEX => {
+                let size = self.ser_function(args)?;
                 Ok(Some(RuntimeValue::I32(size as i32)))
             }
 
@@ -348,27 +298,24 @@ impl<'a, T: TrackingCopy + 'a> Externals for Runtime<'a, T> {
                 Ok(None)
             }
 
-            READ_FUNC_INDEX => {
-                let _ = self.read(args)?;
+            GET_READ_FUNC_INDEX => {
+                let _ = self.set_mem(args)?;
                 Ok(None)
             }
 
-            FN_BYTES_FUNC_INDEX => {
-                let _ = self.function_bytes(args)?;
+            GET_FN_FUNC_INDEX => {
+                let _ = self.set_mem(args)?;
                 Ok(None)
             }
 
-            SIZE_OF_ARG_FUNC_INDEX => {
+            LOAD_ARG_FUNC_INDEX => {
                 let i: u32 = args.nth_checked(0)?;
-                let size = self.size_of_arg(i as usize)?;
+                let size = self.load_arg(i as usize)?;
                 Ok(Some(RuntimeValue::I32(size as i32)))
             }
 
             GET_ARG_FUNC_INDEX => {
-                let i: u32 = args.nth_checked(0)?;
-                let dest_ptr: u32 = args.nth_checked(1)?;
-
-                let _ = self.get_arg(i as usize, dest_ptr)?;
+                let _ = self.set_mem(args)?;
                 Ok(None)
             }
 
@@ -379,35 +326,19 @@ impl<'a, T: TrackingCopy + 'a> Externals for Runtime<'a, T> {
                 Err(self.ret(value_ptr, value_size as usize))
             }
 
-            SIZE_OF_CALL_RESULT_FUNC_INDEX => {
-                let fn_ptr: u32 = args.nth_checked(0)?;
-                let fn_size: u32 = args.nth_checked(1)?;
-                let args_ptr: u32 = args.nth_checked(2)?;
-                let args_size: u32 = args.nth_checked(3)?;
-
-                let size = self.size_of_call_result(
-                    fn_ptr,
-                    fn_size as usize,
-                    args_ptr,
-                    args_size as usize,
-                )?;
-                Ok(Some(RuntimeValue::I32(size as i32)))
-            }
-
             CALL_CONTRACT_FUNC_INDEX => {
                 let fn_ptr: u32 = args.nth_checked(0)?;
                 let fn_size: u32 = args.nth_checked(1)?;
                 let args_ptr: u32 = args.nth_checked(2)?;
                 let args_size: u32 = args.nth_checked(3)?;
-                let result_ptr: u32 = args.nth_checked(4)?;
 
-                let _ = self.call_contract(
-                    fn_ptr,
-                    fn_size as usize,
-                    args_ptr,
-                    args_size as usize,
-                    result_ptr,
-                )?;
+                let size =
+                    self.call_contract(fn_ptr, fn_size as usize, args_ptr, args_size as usize)?;
+                Ok(Some(RuntimeValue::I32(size as i32)))
+            }
+
+            GET_CALL_RESULT_FUNC_INDEX => {
+                let _ = self.set_mem(args)?;
                 Ok(None)
             }
 
@@ -445,25 +376,25 @@ impl<'a> ModuleImportResolver for RuntimeModuleImportResolver {
         _signature: &Signature,
     ) -> Result<FuncRef, InterpreterError> {
         let func_ref = match field_name {
-            "size_of_value" => FuncInstance::alloc_host(
+            "read_value" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 2][..], Some(ValueType::I32)),
-                SIZE_FUNC_INDEX,
+                READ_FUNC_INDEX,
             ),
-            "function_size" => FuncInstance::alloc_host(
+            "serialize_function" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 2][..], Some(ValueType::I32)),
-                FN_SIZE_FUNC_INDEX,
+                SER_FN_FUNC_INDEX,
             ),
             "write" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 4][..], None),
                 WRITE_FUNC_INDEX,
             ),
-            "read" => FuncInstance::alloc_host(
-                Signature::new(&[ValueType::I32; 4][..], None),
-                READ_FUNC_INDEX,
+            "get_read" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32; 1][..], None),
+                GET_READ_FUNC_INDEX,
             ),
-            "function_bytes" => FuncInstance::alloc_host(
-                Signature::new(&[ValueType::I32; 4][..], None),
-                FN_BYTES_FUNC_INDEX,
+            "get_function" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32; 1][..], None),
+                GET_FN_FUNC_INDEX,
             ),
             "add" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 4][..], None),
@@ -473,25 +404,25 @@ impl<'a> ModuleImportResolver for RuntimeModuleImportResolver {
                 Signature::new(&[ValueType::I32; 1][..], None),
                 NEW_FUNC_INDEX,
             ),
-            "size_of_arg" => FuncInstance::alloc_host(
+            "load_arg" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 1][..], Some(ValueType::I32)),
-                SIZE_OF_ARG_FUNC_INDEX,
+                LOAD_ARG_FUNC_INDEX,
             ),
             "get_arg" => FuncInstance::alloc_host(
-                Signature::new(&[ValueType::I32; 3][..], None),
+                Signature::new(&[ValueType::I32; 1][..], None),
                 GET_ARG_FUNC_INDEX,
             ),
             "ret" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 2][..], None),
                 RET_FUNC_INDEX,
             ),
-            "size_of_call_result" => FuncInstance::alloc_host(
-                Signature::new(&[ValueType::I32; 4][..], Some(ValueType::I32)),
-                SIZE_OF_CALL_RESULT_FUNC_INDEX,
-            ),
             "call_contract" => FuncInstance::alloc_host(
-                Signature::new(&[ValueType::I32; 6][..], None),
+                Signature::new(&[ValueType::I32; 4][..], Some(ValueType::I32)),
                 CALL_CONTRACT_FUNC_INDEX,
+            ),
+            "get_call_result" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32; 1][..], None),
+                GET_CALL_RESULT_FUNC_INDEX,
             ),
             _ => {
                 return Err(InterpreterError::Function(format!(
@@ -556,6 +487,7 @@ fn sub_call<T: TrackingCopy>(
         known_urefs,
         module: parity_module,
         result: Vec::new(),
+        host_buf: Vec::new(),
     };
 
     let result = instance.invoke_export("call", &[], &mut runtime);
@@ -592,6 +524,7 @@ pub fn exec<T: TrackingCopy, G: GlobalState<T>>(
         known_urefs,
         module: parity_module,
         result: Vec::new(),
+        host_buf: Vec::new(),
     };
     let _ = instance.invoke_export("call", &[], &mut runtime)?;
 


### PR DESCRIPTION
Runtime caches values which will be passed to wasm, returning the size of the byte array which will be written to memory on the next call (this prevents a lot of work from being done twice)